### PR TITLE
Improve linting in reference project

### DIFF
--- a/python/refproj/.github/workflows/actions.yaml
+++ b/python/refproj/.github/workflows/actions.yaml
@@ -32,6 +32,7 @@ jobs:
 
         # Lint and test
         uv run --locked pyright .
+        uv run --locked ruff format --check
         uv run --locked ruff check .
         uv run --locked pytest .
 

--- a/python/refproj/CHANGELOG.md
+++ b/python/refproj/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.2.1 2025-09-10
+
+### Changed
+
+* Use `ruff format --check` in example github actions
+* Remove isort from linter configuration
+
 ## 0.2.0 2025-08-26
 
 ### Changed

--- a/python/refproj/pyproject.toml
+++ b/python/refproj/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "refproj"
-version = "0.2.0"
+version = "0.2.1"
 description = "Add your description here"
 readme = "README.md"
 authors = [
@@ -52,6 +52,4 @@ select = [
     "B",
     # flake8-simplify
     "SIM",
-    # isort
-    "I",
 ]


### PR DESCRIPTION
In python/refproj:

## 0.2.1 2025-09-10

### Changed

* Use `ruff format --check` in example github actions
* Remove isort from linter configuration